### PR TITLE
Make MessageSerializer.text field required

### DIFF
--- a/telegrambot/serializers.py
+++ b/telegrambot/serializers.py
@@ -32,6 +32,7 @@ class MessageSerializer(serializers.HyperlinkedModelSerializer):
     from_ = UserSerializer(many=False, source="from_user")
     chat = ChatSerializer(many=False)
     date = TimestampField()
+    text = serializers.CharField(required=True)
     
     def __init__(self, *args, **kwargs):
         super(MessageSerializer, self).__init__(*args, **kwargs)


### PR DESCRIPTION
As documented in https://core.telegram.org/bots/api#message, `Message.text` is optional. When we get an update without `text` in its `message`, `KeyError` is raised because of depending on `validated_data['message']['text']`. By making it required, updates without `text` field will get 400-status response instead of 500.