### PR TITLE
Prepare to dependencies update

### DIFF
--- a/telegrambot/models/bot.py
+++ b/telegrambot/models/bot.py
@@ -77,7 +77,10 @@ def set_api(sender, instance, **kwargs):
     #  complete  Bot instance with api data
     if not instance.user_api:
         bot_api = instance._bot.getMe()
-        user_api, _ = User.objects.get_or_create(**bot_api.to_dict())
+        user_dict = bot_api.to_dict()
+        user_fields = [field.name for field in User._meta.get_fields(include_parents=False, include_hidden=False)]
+        safe_dict = {key: value for key, value in user_dict.items() if key in user_fields}
+        user_api, _ = User.objects.get_or_create(**safe_dict)
         instance.user_api = user_api
         instance.save()
         logger.info("Success: Bot api info for bot %s set" % str(instance))


### PR DESCRIPTION
Thank you for you module!

Unfortunately, I've found after some updates of Telegram and dependencies API, some methods (``set_api`` called on ``post_save`` signal) started to get dict with unknown parameters. I'd like to propose a patch to filter out such optional parameters and make the function more robust to further changes.

Unfortuately, I was not able to test a code, because all tests are broken suddenly and return 429 from Telegram API. How can we test them?

Any feedback is appreciated!
Thank you!